### PR TITLE
Add Admin notifications feature

### DIFF
--- a/raffle-draw-api/app/routes.js
+++ b/raffle-draw-api/app/routes.js
@@ -3,6 +3,7 @@ const router = require("express").Router();
 router.use("/api/v1/tickets", require("../routes/ticket"));
 router.use("/api/v1/admin", require("../routes/adminRoutes"));
 router.use("/api/v1/admins", require("../routes/adminRoutes"));
+router.use("/api/v1/admin-notifications", require("../routes/adminNotificationRoutes"));
 
 
 router.get("/health", (_req, res) => {

--- a/raffle-draw-api/controller/notificationController.js
+++ b/raffle-draw-api/controller/notificationController.js
@@ -1,0 +1,20 @@
+const db = require('../db/notificationDb');
+
+exports.getAll = (_req, res) => {
+  const notes = db.find();
+  res.json(notes);
+};
+
+exports.getByUser = (req, res) => {
+  const notes = db.findByUserId(req.params.userId);
+  res.json(notes);
+};
+
+exports.create = (req, res) => {
+  const { userId, message } = req.body;
+  if (!userId || !message) {
+    return res.status(400).json({ message: 'userId and message required' });
+  }
+  const note = db.create(userId, message);
+  res.status(201).json(note);
+};

--- a/raffle-draw-api/db/notificationDb.js
+++ b/raffle-draw-api/db/notificationDb.js
@@ -1,0 +1,23 @@
+const AdminNotification = require('../models/AdminNotification');
+
+class NotificationDB {
+  constructor() {
+    this.notifications = [];
+  }
+
+  create(userId, message) {
+    const note = new AdminNotification(userId, message);
+    this.notifications.push(note);
+    return note;
+  }
+
+  find() {
+    return this.notifications;
+  }
+
+  findByUserId(userId) {
+    return this.notifications.filter((n) => n.userId === userId);
+  }
+}
+
+module.exports = new NotificationDB();

--- a/raffle-draw-api/models/AdminNotification.js
+++ b/raffle-draw-api/models/AdminNotification.js
@@ -1,0 +1,15 @@
+const shortId = require('shortid');
+
+class AdminNotification {
+  constructor(userId, message) {
+    if (!userId || !message) {
+      throw new Error('userId and message are required');
+    }
+    this.id = shortId.generate();
+    this.userId = userId;
+    this.message = message;
+    this.createdAt = new Date();
+  }
+}
+
+module.exports = AdminNotification;

--- a/raffle-draw-api/routes/adminNotificationRoutes.js
+++ b/raffle-draw-api/routes/adminNotificationRoutes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const controller = require('../controller/notificationController');
+const authenticateToken = require('../middleware/authMiddleware');
+
+router.get('/', authenticateToken, controller.getAll);
+router.post('/', authenticateToken, controller.create);
+router.get('/user/:userId', authenticateToken, controller.getByUser);
+
+module.exports = router;

--- a/raffle-ui/src/components/AdminNotifications.js
+++ b/raffle-ui/src/components/AdminNotifications.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+const AdminNotifications = () => {
+  const [notifications, setNotifications] = useState([]);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      const token = localStorage.getItem('token');
+      try {
+        const res = await fetch(
+          `${process.env.REACT_APP_API_URL}/api/v1/admin-notifications`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setNotifications(data);
+        }
+      } catch (err) {
+        console.error('Error fetching notifications', err);
+      }
+    };
+
+    fetchNotifications();
+  }, []);
+
+  return (
+    <div>
+      <h3>Admin Notifications</h3>
+      <ul>
+        {notifications.map((n) => (
+          <li key={n.id}>{n.message}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminNotifications;

--- a/raffle-ui/src/pages/Dashboard.js
+++ b/raffle-ui/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
+import AdminNotifications from '../components/AdminNotifications';
 
 function Dashboard() {
   const navigate = useNavigate();
@@ -52,6 +53,7 @@ function Dashboard() {
       <div className="content-wrapper p-4">
         <h2>Bienvenido, {user?.name} 👋</h2>
         <p>Acá puedes agregar tus gráficos, tablas, etc.</p>
+        <AdminNotifications />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement AdminNotification class and in-memory DB in API
- add controller and routes for notifications
- expose new route in the express app
- show admin notifications in the dashboard via new component

## Testing
- `npm test --prefix raffle-ui -- -w 1 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e05cb0a38832e918d8a0f37df608f