### PR TITLE
Fix dashboard styles by loading App.css

### DIFF
--- a/raffle-ui/src/index.js
+++ b/raffle-ui/src/index.js
@@ -13,6 +13,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import './styles/admin.css';
+import './App.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 


### PR DESCRIPTION
## Summary
- load `App.css` in the UI entrypoint so global styles are applied

## Testing
- `npm --prefix raffle-ui test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e29cc9428832e8c5d225d6c98a58a