### PR TITLE
Load CSS from public assets

### DIFF
--- a/raffle-ui/src/index.js
+++ b/raffle-ui/src/index.js
@@ -17,7 +17,11 @@ import './App.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-
+// Load styles located in the public assets folder
+const publicStyle = document.createElement('link');
+publicStyle.rel = 'stylesheet';
+publicStyle.href = `${process.env.PUBLIC_URL}/assets/admin/css/app.css`;
+document.head.appendChild(publicStyle);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- load `app.css` from the public assets folder on startup

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e31bb1d2c832eb9a7ed6a6a77c044