### PR TITLE
Fix sidebar color class

### DIFF
--- a/raffle-ui/src/components/Sidebar.js
+++ b/raffle-ui/src/components/Sidebar.js
@@ -26,7 +26,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="bg-[#0c1245] text-white h-screen w-64 fixed flex flex-col p-4 shadow-lg">
+    <div className="sidebar h-screen w-64 fixed flex flex-col p-4 shadow-lg">
       <div className="flex items-center gap-3 mb-8 text-2xl font-bold">
         <img src="/assets/images/logoIcon/logo.png" alt="Logo" className="h-10" />
         LottoLab
@@ -56,7 +56,7 @@ const SidebarItem = ({ icon, label, onClick, badge, dropdown }) => {
   return (
     <div>
       <div
-        className="flex justify-between items-center px-3 py-2 rounded-md cursor-pointer hover:bg-[#1e2a78] transition-colors"
+        className="sidebar-item flex justify-between items-center px-3 py-2 rounded-md cursor-pointer transition-colors"
         onClick={onClick}
       >
         <div className="flex items-center gap-3">

--- a/raffle-ui/src/styles/admin.css
+++ b/raffle-ui/src/styles/admin.css
@@ -93,3 +93,7 @@ input:not([type='radio']), textarea { padding:10px 20px; border-radius:5px; back
 .table td{font-size:0.8125rem;color:#5b6e88;text-align:center;font-weight:500;padding:15px 25px;vertical-align:middle;white-space:nowrap;}
 
 
+
+/* Sidebar */
+.sidebar { background-color: #071251; color: #fff; }
+.sidebar-item:hover { background-color: #1e2a78; }


### PR DESCRIPTION
## Summary
- use existing admin styles for sidebar colors
- add sidebar hover styles in admin.css

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e390f9fdc832e8144fa059dd10ee9