### PR TITLE
Update dashboard widgets style

### DIFF
--- a/raffle-ui/src/pages/Dashboard.js
+++ b/raffle-ui/src/pages/Dashboard.js
@@ -83,14 +83,21 @@ function Dashboard() {
       <div className="row">
         {boxes.map((b) => (
           <div key={b.label} className="col-lg-3 col-sm-6 mb-4">
-            <div className={`small-box ${b.color}`}>
-              <div className="inner">
-                <h3>{b.value}</h3>
-                <p>{b.label}</p>
+            <div className={`widget-seven ${b.color}`}>
+              <div className="widget-seven__content">
+                <span className="widget-seven__content-icon">
+                  <span className="icon">
+                    <i className={`fas ${b.icon}`}></i>
+                  </span>
+                </span>
+                <div className="widget-seven__description">
+                  <p className="widget-seven__content-title">{b.label}</p>
+                  <h3 className="widget-seven__content-amount">{b.value}</h3>
+                </div>
               </div>
-              <div className="icon">
-                <i className={`fas ${b.icon}`}></i>
-              </div>
+              <span className="widget-seven__arrow">
+                <i className="fas fa-chevron-right"></i>
+              </span>
             </div>
           </div>
         ))}

--- a/raffle-ui/src/styles/admin.css
+++ b/raffle-ui/src/styles/admin.css
@@ -97,3 +97,42 @@ input:not([type='radio']), textarea { padding:10px 20px; border-radius:5px; back
 /* Sidebar */
 .sidebar { background-color: #071251; color: #fff; }
 .sidebar-item:hover { background-color: #1e2a78; }
+
+/* Dashboard Widget Seven */
+.widget-seven {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 20px;
+  border-radius: 5px;
+  color: #fff;
+}
+
+.widget-seven__content {
+  display: flex;
+  align-items: center;
+}
+
+.widget-seven__content-icon .icon {
+  font-size: 30px;
+  line-height: 1;
+}
+
+.widget-seven__description {
+  margin-left: 10px;
+}
+
+.widget-seven__content-title {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.widget-seven__content-amount {
+  margin: 0;
+  font-size: 1.375rem;
+  font-weight: 600;
+}
+
+.widget-seven__arrow i {
+  font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- restyle dashboard boxes using a new `widget-seven` layout
- add CSS rules for `widget-seven` widget

## Testing
- `npm test -- -w 1 --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4133e8a4832e873dd59c40c113d5