### PR TITLE
Integrate extra css libraries

### DIFF
--- a/raffle-ui/public/assets/global/css/iziToast_custom.css
+++ b/raffle-ui/public/assets/global/css/iziToast_custom.css
@@ -1,0 +1,1 @@
+/* Custom iziToast styles */

--- a/raffle-ui/src/index.js
+++ b/raffle-ui/src/index.js
@@ -13,15 +13,33 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import './styles/admin.css';
+import './styles/content.css';
 import './App.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 // Load styles located in the public assets folder
-const publicStyle = document.createElement('link');
-publicStyle.rel = 'stylesheet';
-publicStyle.href = `${process.env.PUBLIC_URL}/assets/admin/css/app.css`;
-document.head.appendChild(publicStyle);
+const styleHrefs = [
+  'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap',
+  `${process.env.PUBLIC_URL}/assets/admin/css/vendor/bootstrap.min.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/vendor/bootstrap-toggle.min.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/all.min.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/line-awesome.min.css`,
+  'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css',
+  `${process.env.PUBLIC_URL}/assets/admin/css/vendor/select2.min.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/app.css`,
+  `${process.env.PUBLIC_URL}/assets/global/css/iziToast.min.css`,
+  `${process.env.PUBLIC_URL}/assets/global/css/iziToast_custom.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/reset.css`,
+  `${process.env.PUBLIC_URL}/assets/admin/css/content.css`,
+];
+
+styleHrefs.forEach((href) => {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/raffle-ui/src/styles/content.css
+++ b/raffle-ui/src/styles/content.css
@@ -1,0 +1,4 @@
+/* Additional content styles */
+.content-wrapper {
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- add missing global toast custom style
- introduce content.css for shared page layout
- load additional UI libraries such as Poppins font, bootstrap-toggle and iziToast from index.js

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f387ae034832eb1e33fe81a95ecab