### PR TITLE
Fix sidebar links to avoid blocked javascript URLs

### DIFF
--- a/raffle-ui/src/components/Sidebar.js
+++ b/raffle-ui/src/components/Sidebar.js
@@ -143,7 +143,11 @@ const MenuItem = ({ item, open, onToggle, onNavigate }) => {
   if (item.subItems) {
     return (
       <li className={`sidebar-menu-item sidebar-dropdown ${open ? 'open' : ''}`}>
-        <a href="javascript:void(0)" onClick={onToggle} className={open ? 'side-menu--open' : ''}>
+        <button
+          type="button"
+          onClick={onToggle}
+          className={open ? 'side-menu--open' : ''}
+        >
           <i className={`menu-icon ${item.icon}`}></i>
           <span className="menu-title">{item.label}</span>
           {item.badge && (
@@ -151,18 +155,22 @@ const MenuItem = ({ item, open, onToggle, onNavigate }) => {
               <i className="fas fa-exclamation"></i>
             </span>
           )}
-        </a>
+        </button>
         <div className={`sidebar-submenu ${open ? 'sidebar-submenu__open' : ''}`}>
           <ul>
             {item.subItems.map((sub, idx) => (
               <li key={idx} className="sidebar-menu-item">
-                <a onClick={() => onNavigate(sub.to)} className="nav-link">
+                <button
+                  type="button"
+                  onClick={() => onNavigate(sub.to)}
+                  className="nav-link"
+                >
                   <i className="menu-icon las la-dot-circle"></i>
                   <span className="menu-title">{sub.label}</span>
                   {sub.badge && (
                     <span className="menu-badge bg--info ms-auto">{sub.badge}</span>
                   )}
-                </a>
+                </button>
               </li>
             ))}
           </ul>
@@ -173,10 +181,10 @@ const MenuItem = ({ item, open, onToggle, onNavigate }) => {
 
   return (
     <li className="sidebar-menu-item">
-      <a onClick={() => onNavigate(item.to)} className="nav-link">
+      <button type="button" onClick={() => onNavigate(item.to)} className="nav-link">
         <i className={`menu-icon ${item.icon}`}></i>
         <span className="menu-title">{item.label}</span>
-      </a>
+      </button>
     </li>
   );
 };


### PR DESCRIPTION
## Summary
- replace `javascript:void(0)` menu links with `<button>`s
- make submenu and item links buttons to avoid empty hrefs

## Testing
- `npm --prefix raffle-ui test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f42af64a8832e9084824c4e9e4299