### PR TITLE
Fix sidebar menu button spacing

### DIFF
--- a/raffle-ui/src/styles/admin.css
+++ b/raffle-ui/src/styles/admin.css
@@ -146,3 +146,26 @@ input:not([type='radio']), textarea { padding:10px 20px; border-radius:5px; back
 .widget-seven__arrow i {
   font-size: 16px;
 }
+/* Sidebar menu button styles to align with theme */
+.sidebar__menu .sidebar-menu-item > button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 12px 25px;
+  background: transparent;
+  border: none;
+  text-align: left;
+}
+
+.sidebar__menu .sidebar-menu-item > button:hover {
+  background-color: #EBECF0;
+  padding-left: 25px;
+}
+
+.sidebar__menu .sidebar-menu-item > button .menu-icon {
+  margin-right: 15px;
+}
+
+.sidebar__menu .sidebar-submenu .sidebar-menu-item > button {
+  padding: 10px 20px 10px 35px;
+}


### PR DESCRIPTION
## Summary
- adjust sidebar button styles so menu icons match the theme spacing

## Testing
- `npm --prefix raffle-ui test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f4bc25084832e9e8bf9c3f2314f0a