### PR TITLE
Add logo back to sidebar

### DIFF
--- a/raffle-ui/src/components/Sidebar.js
+++ b/raffle-ui/src/components/Sidebar.js
@@ -122,6 +122,11 @@ const Sidebar = () => {
 
   return (
     <div className="sidebar">
+      <div className="sidebar__logo">
+        <div className="sidebar__main-logo">
+          <img src="/assets/images/logoIcon/logo.png" alt="Logo" />
+        </div>
+      </div>
       <div id="sidebar__menuWrapper" className="sidebar__menu-wrapper">
         <ul className="sidebar__menu">
           {menuData.map((item, idx) => (


### PR DESCRIPTION
## Summary
- restore LottoLab logo in sidebar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f51b70440832e8677af6c08a004ae