### PR TITLE
Fix sidebar logo height and dashboard overflow

### DIFF
--- a/raffle-ui/src/layouts/ProtectedLayout.js
+++ b/raffle-ui/src/layouts/ProtectedLayout.js
@@ -8,7 +8,13 @@ const ProtectedLayout = ({ children }) => {
       <Sidebar />
       <div style={{ width: '100%' }}>
         <Navbar />
-        <main style={{ marginLeft: '16rem', padding: '1rem', width: '100%' }}>
+        <main
+          style={{
+            marginLeft: '250px',
+            width: 'calc(100% - 250px)',
+            padding: '1rem',
+          }}
+        >
           {children}
         </main>
       </div>

--- a/raffle-ui/src/styles/admin.css
+++ b/raffle-ui/src/styles/admin.css
@@ -172,9 +172,12 @@ input:not([type='radio']), textarea { padding:10px 20px; border-radius:5px; back
 
 /* Ajustar la zona del logo para que coincida con la altura de la barra de navegación */
 .sidebar__logo {
-  padding: 15px 10px;
+  height: 60px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
 }
 
 .sidebar__logo .sidebar__main-logo img {
-  max-height: 35px;
+  max-height: 40px;
 }


### PR DESCRIPTION
## Summary
- keep content width within viewport by adjusting layout
- align sidebar logo area with navbar height

## Testing
- `npm --prefix raffle-ui test -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e36caf4832ea4c0e64300326ca6