### PR TITLE
Add test scripts for root and API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently \"npm --prefix raffle-draw-api start\" \"npm --prefix raffle-ui start\""
+    "start": "concurrently \"npm --prefix raffle-draw-api start\" \"npm --prefix raffle-ui start\"",
+    "test": "npm --prefix raffle-draw-api test && npm --prefix raffle-ui test"
   },
   "keywords": [],
   "author": "",

--- a/raffle-draw-api/package.json
+++ b/raffle-draw-api/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "echo \"No tests implemented\" && exit 0"
   },
   "packageManager": "yarn@3.2.1"
 }


### PR DESCRIPTION
## Summary
- add placeholder test command to API
- add root-level test script to run both projects

## Testing
- `npm --prefix raffle-draw-api test`
- `npm --prefix raffle-ui test` *(fails: react-scripts not found)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e30dbc4832ea71f52b994ae1803