### PR TITLE
Fix navbar wrapper height

### DIFF
--- a/raffle-ui/src/styles/admin.css
+++ b/raffle-ui/src/styles/admin.css
@@ -181,3 +181,11 @@ input:not([type='radio']), textarea { padding:10px 20px; border-radius:5px; back
 .sidebar__logo .sidebar__main-logo img {
   max-height: 40px;
 }
+
+/* Align the navbar with the sidebar logo */
+.navbar-wrapper {
+  height: 60px;
+  padding: 0 30px;
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- ensure the navbar wrapper matches sidebar logo height

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f60bf3488832e9d342b1f480dd809