### PR TITLE
Fix missing CSS source map warning

### DIFF
--- a/raffle-ui/src/styles/app.css
+++ b/raffle-ui/src/styles/app.css
@@ -6743,7 +6743,6 @@ th.w-85 {
 
 /* dark version css end */
 
-/*# sourceMappingURL=app.css.map */
 .image-upload .thumb .profilePicPreview {
     width: 100%;
     height: 310px;


### PR DESCRIPTION
## Summary
- remove stale `app.css.map` reference to silence source-map warning

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8715f58832e8b813e27e6144160