### PR TITLE
Add lottery management endpoints and React pages

### DIFF
--- a/raffle-draw-api/app/routes.js
+++ b/raffle-draw-api/app/routes.js
@@ -4,6 +4,7 @@ router.use("/api/v1/admin", require("../routes/adminRoutes"));
 router.use("/api/v1/admins", require("../routes/adminRoutes"));
 router.use("/api/v1/admin-notifications", require("../routes/adminNotificationRoutes"));
 router.use("/api/v1/dashboard", require("../routes/dashboardRoutes"));
+router.use("/api/v1/lotteries", require("../routes/lotteryRoutes"));
 
 
 router.get("/health", (_req, res) => {

--- a/raffle-draw-api/controller/lotteryController.js
+++ b/raffle-draw-api/controller/lotteryController.js
@@ -1,0 +1,87 @@
+const Lottery = require('../models/lotteryModel');
+const Phase = require('../models/phaseModel');
+const WinBonus = require('../models/winBonusModel');
+
+exports.getAll = async (_req, res) => {
+  const lotteries = await Lottery.findAll();
+  res.json(lotteries);
+};
+
+exports.getById = async (req, res) => {
+  const lottery = await Lottery.findById(req.params.id);
+  if (!lottery) return res.status(404).json({ message: 'Not found' });
+  res.json(lottery);
+};
+
+exports.create = async (req, res) => {
+  const { name, price, detail, image } = req.body;
+  if (!name || !price) return res.status(400).json({ message: 'Invalid data' });
+  try {
+    const { id } = await Lottery.create({ name, price, detail, image });
+    res.status(201).json({ id });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+exports.update = async (req, res) => {
+  const { name, price, detail, image } = req.body;
+  try {
+    await Lottery.update(req.params.id, { name, price, detail, image });
+    res.json({ message: 'Updated' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+exports.toggleStatus = async (req, res) => {
+  await Lottery.toggleStatus(req.params.id);
+  res.json({ message: 'Status updated' });
+};
+
+exports.getPhases = async (req, res) => {
+  const phases = await Phase.findByLottery(req.params.lotteryId);
+  res.json(phases);
+};
+
+exports.createPhase = async (req, res) => {
+  const { start, end, quantity, at_dr } = req.body;
+  const phases = await Phase.findByLottery(req.params.lotteryId);
+  const phase_number = phases.length + 1;
+  const available = quantity;
+  const { id } = await Phase.create({
+    lottery_id: req.params.lotteryId,
+    phase_number,
+    start,
+    end,
+    quantity,
+    available,
+    at_dr,
+  });
+  res.status(201).json({ id });
+};
+
+exports.updatePhase = async (req, res) => {
+  const { start, end, quantity, available, at_dr } = req.body;
+  await Phase.update(req.params.id, { start, end, quantity, available, at_dr });
+  res.json({ message: 'Phase updated' });
+};
+
+exports.togglePhaseStatus = async (req, res) => {
+  await Phase.toggleStatus(req.params.id);
+  res.json({ message: 'Phase status updated' });
+};
+
+exports.getBonuses = async (req, res) => {
+  const bonuses = await WinBonus.findByLottery(req.params.lotteryId);
+  res.json(bonuses);
+};
+
+exports.setBonuses = async (req, res) => {
+  const { levels } = req.body; // [{level, amount}]
+  await WinBonus.deleteByLottery(req.params.lotteryId);
+  for (const b of levels) {
+    await WinBonus.create({ lottery_id: req.params.lotteryId, level: b.level, amount: b.amount });
+  }
+  res.json({ message: 'Bonuses saved' });
+};

--- a/raffle-draw-api/db/init.js
+++ b/raffle-draw-api/db/init.js
@@ -53,6 +53,53 @@ async function initialize() {
     await pool.query(sql);
     console.log("✅ Tabla 'admins' verificada o creada");
 
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS lotteries (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        price DECIMAL(10,2) NOT NULL,
+        detail TEXT,
+        image VARCHAR(255),
+        status TINYINT DEFAULT 1,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB;
+    `);
+    console.log("✅ Tabla 'lotteries' lista");
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS phases (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        lottery_id BIGINT UNSIGNED NOT NULL,
+        phase_number INT NOT NULL,
+        start DATETIME NOT NULL,
+        end DATETIME NOT NULL,
+        quantity INT NOT NULL,
+        available INT NOT NULL,
+        at_dr TINYINT DEFAULT 1,
+        status TINYINT DEFAULT 1,
+        draw_status TINYINT DEFAULT 0,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        FOREIGN KEY (lottery_id) REFERENCES lotteries(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB;
+    `);
+    console.log("✅ Tabla 'phases' lista");
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS win_bonuses (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        lottery_id BIGINT UNSIGNED NOT NULL,
+        level INT NOT NULL,
+        amount DECIMAL(10,2) NOT NULL,
+        status TINYINT DEFAULT 1,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        FOREIGN KEY (lottery_id) REFERENCES lotteries(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB;
+    `);
+    console.log("✅ Tabla 'win_bonuses' lista");
+
     // 5. Verificar si hay algún admin
     const [rows] = await pool.query(`SELECT COUNT(*) AS total FROM admins`);
     if (rows[0].total === 0) {

--- a/raffle-draw-api/models/lotteryModel.js
+++ b/raffle-draw-api/models/lotteryModel.js
@@ -1,0 +1,30 @@
+const db = require('../db/mysql');
+
+const Lottery = {
+  findAll: async () => {
+    const [rows] = await db.query('SELECT * FROM lotteries ORDER BY id DESC');
+    return rows;
+  },
+  findById: async (id) => {
+    const [rows] = await db.query('SELECT * FROM lotteries WHERE id = ?', [id]);
+    return rows[0];
+  },
+  create: async ({ name, price, detail, image }) => {
+    const [result] = await db.query(
+      'INSERT INTO lotteries (name, price, detail, image, status) VALUES (?, ?, ?, ?, 1)',
+      [name, price, detail, image]
+    );
+    return { id: result.insertId };
+  },
+  update: async (id, { name, price, detail, image }) => {
+    await db.query(
+      'UPDATE lotteries SET name=?, price=?, detail=?, image=?, updated_at=CURRENT_TIMESTAMP WHERE id=?',
+      [name, price, detail, image, id]
+    );
+  },
+  toggleStatus: async (id) => {
+    await db.query('UPDATE lotteries SET status = IF(status=1,0,1) WHERE id=?', [id]);
+  },
+};
+
+module.exports = Lottery;

--- a/raffle-draw-api/models/phaseModel.js
+++ b/raffle-draw-api/models/phaseModel.js
@@ -1,0 +1,31 @@
+const db = require('../db/mysql');
+
+const Phase = {
+  findByLottery: async (lotteryId) => {
+    const [rows] = await db.query('SELECT * FROM phases WHERE lottery_id=? ORDER BY id DESC', [lotteryId]);
+    return rows;
+  },
+  findById: async (id) => {
+    const [rows] = await db.query('SELECT * FROM phases WHERE id=?', [id]);
+    return rows[0];
+  },
+  create: async ({ lottery_id, phase_number, start, end, quantity, available, at_dr }) => {
+    const [result] = await db.query(
+      `INSERT INTO phases (lottery_id, phase_number, start, end, quantity, available, at_dr, status, draw_status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1, 0)`,
+      [lottery_id, phase_number, start, end, quantity, available, at_dr]
+    );
+    return { id: result.insertId };
+  },
+  update: async (id, { start, end, quantity, available, at_dr }) => {
+    await db.query(
+      'UPDATE phases SET start=?, end=?, quantity=?, available=?, at_dr=?, updated_at=CURRENT_TIMESTAMP WHERE id=?',
+      [start, end, quantity, available, at_dr, id]
+    );
+  },
+  toggleStatus: async (id) => {
+    await db.query('UPDATE phases SET status = IF(status=1,0,1) WHERE id=?', [id]);
+  },
+};
+
+module.exports = Phase;

--- a/raffle-draw-api/models/winBonusModel.js
+++ b/raffle-draw-api/models/winBonusModel.js
@@ -1,0 +1,19 @@
+const db = require('../db/mysql');
+
+const WinBonus = {
+  findByLottery: async (lotteryId) => {
+    const [rows] = await db.query('SELECT * FROM win_bonuses WHERE lottery_id=? ORDER BY level', [lotteryId]);
+    return rows;
+  },
+  deleteByLottery: async (lotteryId) => {
+    await db.query('DELETE FROM win_bonuses WHERE lottery_id=?', [lotteryId]);
+  },
+  create: async ({ lottery_id, level, amount }) => {
+    await db.query(
+      'INSERT INTO win_bonuses (lottery_id, level, amount, status) VALUES (?, ?, ?, 1)',
+      [lottery_id, level, amount]
+    );
+  },
+};
+
+module.exports = WinBonus;

--- a/raffle-draw-api/routes/lotteryRoutes.js
+++ b/raffle-draw-api/routes/lotteryRoutes.js
@@ -1,0 +1,19 @@
+const router = require('express').Router();
+const ctrl = require('../controller/lotteryController');
+const authenticateToken = require('../middleware/authMiddleware');
+
+router.get('/', authenticateToken, ctrl.getAll);
+router.post('/', authenticateToken, ctrl.create);
+router.get('/:id', authenticateToken, ctrl.getById);
+router.put('/:id', authenticateToken, ctrl.update);
+router.patch('/:id/status', authenticateToken, ctrl.toggleStatus);
+
+router.get('/:lotteryId/phases', authenticateToken, ctrl.getPhases);
+router.post('/:lotteryId/phases', authenticateToken, ctrl.createPhase);
+router.put('/phases/:id', authenticateToken, ctrl.updatePhase);
+router.patch('/phases/:id/status', authenticateToken, ctrl.togglePhaseStatus);
+
+router.get('/:lotteryId/bonuses', authenticateToken, ctrl.getBonuses);
+router.post('/:lotteryId/bonuses', authenticateToken, ctrl.setBonuses);
+
+module.exports = router;

--- a/raffle-ui/src/App.js
+++ b/raffle-ui/src/App.js
@@ -3,6 +3,9 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import ForgotPassword from './pages/ForgotPassword';
+import LotteryList from './pages/lottery/List';
+import LotteryCreate from './pages/lottery/Create';
+import LotteryEdit from './pages/lottery/Edit';
 import ProtectedLayout from './layouts/ProtectedLayout';
 
 // Toastify
@@ -29,7 +32,7 @@ function App() {
       />
 
       <Routes>
-        <Route path="/" element={<Navigate to="/Dashboard" />} />
+        <Route path="/" element={<Navigate to="/dashboard" />} />
         <Route path="/login" element={<Login />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
 
@@ -39,6 +42,43 @@ function App() {
             isAuthenticated() ? (
               <ProtectedLayout>
                 <Dashboard />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+
+        <Route
+          path="/lottery"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <LotteryList />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+        <Route
+          path="/lottery/create"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <LotteryCreate />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+        <Route
+          path="/lottery/:id/edit"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <LotteryEdit />
               </ProtectedLayout>
             ) : (
               <Navigate to="/Login" />

--- a/raffle-ui/src/App.test.js
+++ b/raffle-ui/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login page by default', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loginText = screen.getByText(/sign in/i);
+  expect(loginText).toBeInTheDocument();
 });

--- a/raffle-ui/src/pages/lottery/Create.js
+++ b/raffle-ui/src/pages/lottery/Create.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function LotteryCreate() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [detail, setDetail] = useState('');
+  const [image, setImage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ name, price, detail, image }),
+    });
+    if (res.ok) {
+      navigate('/lottery');
+    }
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <h6 className="page-title">Create Lottery</h6>
+      <form onSubmit={handleSubmit} style={{ maxWidth: 400 }}>
+        <div className="mb-2">
+          <input placeholder="Name" className="form-control" value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div className="mb-2">
+          <input type="number" placeholder="Price" className="form-control" value={price} onChange={(e) => setPrice(e.target.value)} required />
+        </div>
+        <div className="mb-2">
+          <textarea placeholder="Detail" className="form-control" value={detail} onChange={(e) => setDetail(e.target.value)} />
+        </div>
+        <div className="mb-2">
+          <input placeholder="Image URL" className="form-control" value={image} onChange={(e) => setImage(e.target.value)} />
+        </div>
+        <button className="btn btn-primary" type="submit">Save</button>
+      </form>
+    </div>
+  );
+}
+
+export default LotteryCreate;

--- a/raffle-ui/src/pages/lottery/Edit.js
+++ b/raffle-ui/src/pages/lottery/Edit.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+function LotteryEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [detail, setDetail] = useState('');
+  const [image, setImage] = useState('');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const token = localStorage.getItem('token');
+      const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setName(data.name || '');
+        setPrice(data.price || '');
+        setDetail(data.detail || '');
+        setImage(data.image || '');
+      }
+    };
+    fetchData();
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ name, price, detail, image }),
+    });
+    if (res.ok) {
+      navigate('/lottery');
+    }
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <h6 className="page-title">Edit Lottery</h6>
+      <form onSubmit={handleSubmit} style={{ maxWidth: 400 }}>
+        <div className="mb-2">
+          <input placeholder="Name" className="form-control" value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div className="mb-2">
+          <input type="number" placeholder="Price" className="form-control" value={price} onChange={(e) => setPrice(e.target.value)} required />
+        </div>
+        <div className="mb-2">
+          <textarea placeholder="Detail" className="form-control" value={detail} onChange={(e) => setDetail(e.target.value)} />
+        </div>
+        <div className="mb-2">
+          <input placeholder="Image URL" className="form-control" value={image} onChange={(e) => setImage(e.target.value)} />
+        </div>
+        <button className="btn btn-primary" type="submit">Save</button>
+      </form>
+    </div>
+  );
+}
+
+export default LotteryEdit;

--- a/raffle-ui/src/pages/lottery/List.js
+++ b/raffle-ui/src/pages/lottery/List.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function LotteryList() {
+  const navigate = useNavigate();
+  const [lotteries, setLotteries] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setLotteries(data);
+        }
+      } catch (err) {
+        console.error('fetch lotteries', err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleEdit = (id) => {
+    navigate(`/lottery/${id}/edit`);
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <div className="d-flex mb-3 justify-content-between align-items-center">
+        <h6 className="page-title">Lotteries</h6>
+        <button className="btn btn-primary" onClick={() => navigate('/lottery/create')}>Create</button>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Price</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {lotteries.map((l) => (
+            <tr key={l.id}>
+              <td>{l.name}</td>
+              <td>{l.price}</td>
+              <td>{l.status ? 'Active' : 'Inactive'}</td>
+              <td>
+                <button className="btn btn-sm btn-secondary" onClick={() => handleEdit(l.id)}>Edit</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default LotteryList;


### PR DESCRIPTION
## Summary
- create backend model/controller/routes for lotteries
- update DB init script to include new tables
- expose new lottery routes
- add React pages for listing, creating and editing lotteries
- update app routing and tests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869f7f7d98832ea541ce5bbb8e2a96