### PR TITLE
Add lottery phases and win bonus management pages

### DIFF
--- a/raffle-ui/src/App.js
+++ b/raffle-ui/src/App.js
@@ -6,6 +6,8 @@ import ForgotPassword from './pages/ForgotPassword';
 import LotteryList from './pages/lottery/List';
 import LotteryCreate from './pages/lottery/Create';
 import LotteryEdit from './pages/lottery/Edit';
+import LotteryPhases from './pages/lottery/Phases';
+import WinBonus from './pages/lottery/WinBonus';
 import ProtectedLayout from './layouts/ProtectedLayout';
 
 // Toastify
@@ -79,6 +81,30 @@ function App() {
             isAuthenticated() ? (
               <ProtectedLayout>
                 <LotteryEdit />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+        <Route
+          path="/lottery/:id/phases"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <LotteryPhases />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+        <Route
+          path="/lottery/:id/bonuses"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <WinBonus />
               </ProtectedLayout>
             ) : (
               <Navigate to="/Login" />

--- a/raffle-ui/src/pages/lottery/List.js
+++ b/raffle-ui/src/pages/lottery/List.js
@@ -27,6 +27,25 @@ function LotteryList() {
     navigate(`/lottery/${id}/edit`);
   };
 
+  const handlePhases = (id) => {
+    navigate(`/lottery/${id}/phases`);
+  };
+
+  const handleBonus = (id) => {
+    navigate(`/lottery/${id}/bonuses`);
+  };
+
+  const toggleStatus = async (id) => {
+    const token = localStorage.getItem('token');
+    await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}/status`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    setLotteries((prev) =>
+      prev.map((l) => (l.id === id ? { ...l, status: l.status ? 0 : 1 } : l))
+    );
+  };
+
   return (
     <div className="bodywrapper__inner">
       <div className="d-flex mb-3 justify-content-between align-items-center">
@@ -49,7 +68,10 @@ function LotteryList() {
               <td>{l.price}</td>
               <td>{l.status ? 'Active' : 'Inactive'}</td>
               <td>
-                <button className="btn btn-sm btn-secondary" onClick={() => handleEdit(l.id)}>Edit</button>
+                <button className="btn btn-sm btn-secondary me-1" onClick={() => handleEdit(l.id)}>Edit</button>
+                <button className="btn btn-sm btn-info me-1" onClick={() => handlePhases(l.id)}>Phases</button>
+                <button className="btn btn-sm btn-success me-1" onClick={() => handleBonus(l.id)}>Bonuses</button>
+                <button className="btn btn-sm btn-warning" onClick={() => toggleStatus(l.id)}>Toggle</button>
               </td>
             </tr>
           ))}

--- a/raffle-ui/src/pages/lottery/Phases.js
+++ b/raffle-ui/src/pages/lottery/Phases.js
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+function LotteryPhases() {
+  const { id } = useParams();
+  const [lottery, setLottery] = useState(null);
+  const [phases, setPhases] = useState([]);
+  const [form, setForm] = useState({ start: '', end: '', quantity: '', at_dr: '1' });
+  const [editingId, setEditingId] = useState(null);
+
+  const token = localStorage.getItem('token');
+
+  const fetchData = async () => {
+    const headers = { Authorization: `Bearer ${token}` };
+    const resLottery = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}`, { headers });
+    if (resLottery.ok) {
+      const data = await resLottery.json();
+      setLottery(data);
+    }
+    const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}/phases`, { headers });
+    if (res.ok) {
+      const data = await res.json();
+      setPhases(data);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+    const body = JSON.stringify(form);
+    const url = editingId
+      ? `${process.env.REACT_APP_API_URL}/api/v1/phases/${editingId}`
+      : `${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}/phases`;
+    const method = editingId ? 'PUT' : 'POST';
+    const res = await fetch(url, { method, headers, body });
+    if (res.ok) {
+      setForm({ start: '', end: '', quantity: '', at_dr: '1' });
+      setEditingId(null);
+      fetchData();
+    }
+  };
+
+  const editPhase = (phase) => {
+    setForm({
+      start: phase.start ? phase.start.substring(0, 16) : '',
+      end: phase.end ? phase.end.substring(0, 16) : '',
+      quantity: phase.quantity,
+      at_dr: String(phase.at_dr),
+    });
+    setEditingId(phase.id);
+  };
+
+  const toggleStatus = async (pid) => {
+    const headers = { Authorization: `Bearer ${token}` };
+    await fetch(`${process.env.REACT_APP_API_URL}/api/v1/phases/${pid}/status`, { method: 'PATCH', headers });
+    fetchData();
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <h6 className="page-title">Lottery Phases</h6>
+      {lottery && <p><strong>{lottery.name}</strong></p>}
+      <form onSubmit={handleSubmit} className="mb-4" style={{ maxWidth: 500 }}>
+        <div className="mb-2">
+          <label>Start</label>
+          <input type="datetime-local" name="start" className="form-control" value={form.start} onChange={handleChange} required />
+        </div>
+        <div className="mb-2">
+          <label>End</label>
+          <input type="datetime-local" name="end" className="form-control" value={form.end} onChange={handleChange} required />
+        </div>
+        <div className="mb-2">
+          <label>Quantity</label>
+          <input type="number" name="quantity" className="form-control" value={form.quantity} onChange={handleChange} required />
+        </div>
+        <div className="mb-2">
+          <label>Draw Type</label>
+          <select name="at_dr" className="form-control" value={form.at_dr} onChange={handleChange} required>
+            <option value="1">Auto</option>
+            <option value="0">Manual</option>
+          </select>
+        </div>
+        <button className="btn btn-primary" type="submit">{editingId ? 'Update' : 'Create'}</button>
+        {editingId && <button type="button" className="btn btn-secondary ms-2" onClick={() => { setEditingId(null); setForm({ start: '', end: '', quantity: '', at_dr: '1' }); }}>Cancel</button>}
+      </form>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>Quantity</th>
+            <th>Available</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Status</th>
+            <th>Draw</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {phases.map((p) => (
+            <tr key={p.id}>
+              <td>{p.phase_number}</td>
+              <td>{p.quantity}</td>
+              <td>{p.available}</td>
+              <td>{p.start}</td>
+              <td>{p.end}</td>
+              <td>{p.status ? 'Active' : 'Inactive'}</td>
+              <td>{p.at_dr ? 'Auto' : 'Manual'}</td>
+              <td>
+                <button className="btn btn-sm btn-secondary me-1" onClick={() => editPhase(p)}>Edit</button>
+                <button className="btn btn-sm btn-warning" onClick={() => toggleStatus(p.id)}>Toggle</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default LotteryPhases;

--- a/raffle-ui/src/pages/lottery/WinBonus.js
+++ b/raffle-ui/src/pages/lottery/WinBonus.js
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+function WinBonus() {
+  const { id } = useParams();
+  const [lottery, setLottery] = useState(null);
+  const [bonuses, setBonuses] = useState([]);
+  const [levels, setLevels] = useState(0);
+  const [formLevels, setFormLevels] = useState([]);
+
+  const token = localStorage.getItem('token');
+
+  const fetchData = async () => {
+    const headers = { Authorization: `Bearer ${token}` };
+    const resLottery = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}`, { headers });
+    if (resLottery.ok) {
+      const data = await resLottery.json();
+      setLottery(data);
+    }
+    const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}/bonuses`, { headers });
+    if (res.ok) {
+      const data = await res.json();
+      setBonuses(data);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  const generateLevels = () => {
+    const arr = [];
+    for (let i = 1; i <= levels; i++) {
+      arr.push({ level: i, amount: '' });
+    }
+    setFormLevels(arr);
+  };
+
+  const handleAmountChange = (idx, value) => {
+    const arr = [...formLevels];
+    arr[idx].amount = value;
+    setFormLevels(arr);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+    const body = JSON.stringify({ levels: formLevels });
+    const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/lotteries/${id}/bonuses`, { method: 'POST', headers, body });
+    if (res.ok) {
+      setLevels(0);
+      setFormLevels([]);
+      fetchData();
+    }
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <h6 className="page-title">Win Bonus</h6>
+      {lottery && <p><strong>{lottery.name}</strong></p>}
+      <div className="row">
+        <div className="col-md-6">
+          <h6>Current Setting</h6>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Level</th>
+                <th>Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bonuses.map((b) => (
+                <tr key={b.id}>
+                  <td>{b.level}</td>
+                  <td>{b.amount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="col-md-6">
+          <h6>Change Setting</h6>
+          <div className="mb-3 d-flex">
+            <input type="number" className="form-control me-2" value={levels} onChange={(e) => setLevels(e.target.value)} placeholder="How many winner" />
+            <button className="btn btn-primary" type="button" onClick={generateLevels}>Generate</button>
+          </div>
+          {formLevels.length > 0 && (
+            <form onSubmit={handleSubmit}>
+              {formLevels.map((f, idx) => (
+                <div className="input-group mb-2" key={idx}>
+                  <span className="input-group-text">{f.level}</span>
+                  <input type="number" className="form-control" value={f.amount} onChange={(e) => handleAmountChange(idx, e.target.value)} required placeholder="Win Bonus" />
+                </div>
+              ))}
+              <button className="btn btn-primary" type="submit">Save</button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WinBonus;


### PR DESCRIPTION
## Summary
- implement new React pages `Phases` and `WinBonus` for lottery management
- expand lottery list actions to open phases and bonus settings
- add routes for the new pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875e7fd9d8832e9d221e0f7156a03a