### PR TITLE
Update admin lottery list view

### DIFF
--- a/php lottery/core/app/Http/Controllers/Admin/LotteryController.php
+++ b/php lottery/core/app/Http/Controllers/Admin/LotteryController.php
@@ -13,11 +13,16 @@ use HTMLPurifier;
 
 class LotteryController extends Controller
 {
-    public function index(){
-    	$pageTitle = "Lotteries";
-    	$lotteries = Lottery::orderBy('id','desc')->paginate(getPaginate());
-    	$empty_message = "No Data Found";
-    	return view('admin.lottery.index',compact('pageTitle','lotteries','empty_message'));
+    public function index(Request $request){
+        $pageTitle = "Lotteries";
+        $search = $request->search;
+        $lotteries = Lottery::when($search, function ($query, $search) {
+                return $query->where('name', 'like', "%{$search}%");
+            })
+            ->orderBy('id','desc')
+            ->paginate(getPaginate());
+        $empty_message = "No Data Found";
+        return view('admin.lottery.index',compact('pageTitle','lotteries','empty_message','search'));
     }
 
 

--- a/php lottery/core/resources/views/admin/lottery/index.blade.php
+++ b/php lottery/core/resources/views/admin/lottery/index.blade.php
@@ -1,15 +1,16 @@
 @extends('admin.layouts.app')
 
 @section('panel')
-<div class="row">
-
-    <div class="col-lg-12">
-        <div class="card b-radius--10">
+<div class="row justify-content-center">
+    <div class="col-md-12">
+        <div class="card">
             <div class="card-body p-0">
                 <div class="table-responsive--sm table-responsive">
                     <table class="table table--light style--two">
                         <thead>
                             <tr>
+                                <th>@lang('S.N.')</th>
+                                <th>@lang('Image')</th>
                                 <th>@lang('Lottery Name')</th>
                                 <th>@lang('Price')</th>
                                 <th>@lang('Total Phase')</th>
@@ -21,30 +22,55 @@
                         <tbody class="list">
                             @forelse($lotteries as $lottery)
                             <tr>
+                                <td data-label="@lang('S.N.')">{{ $loop->iteration }}</td>
+                                <td data-label="@lang('Image')">
+                                    <div class="customer-details d-block">
+                                        <a class="thumb" href="javascript:void(0)">
+                                            <img src="{{ getImage('assets/images/lottery/' . $lottery->image, imagePath()['lottery']['size']) }}" alt="image">
+                                        </a>
+                                    </div>
+                                </td>
                                 <td data-label="@lang('Lottery Name')">{{ $lottery->name }}</td>
                                 <td data-label="@lang('Price')">{{ getAmount($lottery->price) }} {{ $general->cur_text }}</td>
                                 <td data-label="@lang('Total Phase')">{{ $lottery->phase->count() }}</td>
                                 <td data-label="@lang('Total Draw')">{{ $lottery->phase->where('draw_status',1)->count() }}</td>
                                 <td data-label="@lang('Status')">
                                     @if($lottery->status == 1)
-                                        <span class="text--small badge font-weight-normal badge--success">
-                                            @lang('active')
-                                        </span>
+                                        <span class="badge badge--success">@lang('Active')</span>
                                     @else
-                                        <span class="text--small badge font-weight-normal badge--danger">
-                                            @lang('inactive')
-                                        </span>
+                                        <span class="badge badge--danger">@lang('Inactive')</span>
                                     @endif
                                 </td>
                                 <td data-label="@lang('Action')">
-                                    <a href="{{ route('admin.lottery.edit',$lottery->id) }}" class="icon-btn"><i class="la la-pencil"></i></a>
-                                    <a href="{{ route('admin.lottery.winBonus',$lottery->id) }}" class="icon-btn bg--info" data-toggle="tooltip" data-placement="top" title="@lang('Set Win Bonus')"><i class="las la-trophy"></i></a>
-                                    <a href="{{ route('admin.lottery.phase.singleLottery',$lottery->id) }}" class="icon-btn bg--7" data-toggle="tooltip" data-placement="top" title="@lang('See Phases')"><i class="fas fa-layer-group"></i></a>
-                                    @if($lottery->status == 1)
-                                        <a href="{{ route('admin.lottery.status',$lottery->id) }}" class="icon-btn bg--danger"><i class="la la-eye-slash"></i></a>
-                                    @else
-                                        <a href="{{ route('admin.lottery.status',$lottery->id) }}" class="icon-btn bg--success"><i class="la la-eye"></i></a>
-                                    @endif
+                                    <div class="button--group">
+                                        <a class="btn btn-sm btn-outline--primary editBtn" href="{{ route('admin.lottery.edit',$lottery->id) }}">
+                                            <i class="la la-pen"></i> @lang('Edit')
+                                        </a>
+                                        @if($lottery->status == 1)
+                                            <a class="btn btn-sm btn-outline--danger" href="{{ route('admin.lottery.status',$lottery->id) }}">
+                                                <i class="la la-eye-slash"></i> @lang('Inactive')
+                                            </a>
+                                        @else
+                                            <a class="btn btn-sm btn-outline--success" href="{{ route('admin.lottery.status',$lottery->id) }}">
+                                                <i class="la la-eye"></i> @lang('Active')
+                                            </a>
+                                        @endif
+                                        <button class="btn btn-sm btn-outline--info dropdown-toggle" data-bs-toggle="dropdown" type="button" aria-expanded="false">
+                                            <i class="la la-ellipsis-v"></i> @lang('More')
+                                        </button>
+                                        <div class="dropdown-menu">
+                                            <li>
+                                                <a class="dropdown-item editBtn text--info" href="{{ route('admin.lottery.winBonus',$lottery->id) }}">
+                                                    <i class="las la-trophy"></i> @lang('Set Win Bonus')
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a class="dropdown-item editBtn text--warning" href="{{ route('admin.lottery.phase.singleLottery',$lottery->id) }}">
+                                                    <i class="fas fa-layer-group"></i> @lang('Ticket phases')
+                                                </a>
+                                            </li>
+                                        </div>
+                                    </div>
                                 </td>
                             </tr>
                             @empty
@@ -64,5 +90,11 @@
 </div>
 @endsection
 @push('breadcrumb-plugins')
-<a href="{{ route('admin.lottery.create') }}" class="icon-btn"><i class="fa fa-plus"></i> @lang('Create Lottery')</a> 
+<form method="GET" class="d-flex flex-wrap gap-2">
+    <div class="input-group w-auto flex-fill">
+        <input type="search" name="search" class="form-control bg--white" placeholder="@lang('Search lottery')" value="{{ $search ?? '' }}">
+        <button class="btn btn--primary" type="submit"><i class="la la-search"></i></button>
+    </div>
+</form>
+<a class="btn btn-sm btn-outline--primary" href="{{ route('admin.lottery.create') }}"><i class="la la-plus"></i>@lang('Add New')</a>
 @endpush


### PR DESCRIPTION
## Summary
- allow searching lotteries by name
- revamp lottery list table with serial number, image column and action dropdown

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688762cafce8832e950eaadaa342d8e0