### PR TITLE
Enhance lottery list view

### DIFF
--- a/raffle-ui/src/pages/lottery/List.js
+++ b/raffle-ui/src/pages/lottery/List.js
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 function LotteryList() {
   const navigate = useNavigate();
   const [lotteries, setLotteries] = useState([]);
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
     const fetchData = async () => {
@@ -14,7 +15,27 @@ function LotteryList() {
         });
         if (res.ok) {
           const data = await res.json();
-          setLotteries(data);
+          const withCounts = await Promise.all(
+            data.map(async (l) => {
+              let phaseCount = 0;
+              let drawCount = 0;
+              try {
+                const pres = await fetch(
+                  `${process.env.REACT_APP_API_URL}/api/v1/lotteries/${l.id}/phases`,
+                  { headers: { Authorization: `Bearer ${token}` } }
+                );
+                if (pres.ok) {
+                  const phases = await pres.json();
+                  phaseCount = phases.length;
+                  drawCount = phases.filter((p) => p.draw_status === 1).length;
+                }
+              } catch (err) {
+                console.error('fetch phases', err);
+              }
+              return { ...l, phaseCount, drawCount };
+            })
+          );
+          setLotteries(withCounts);
         }
       } catch (err) {
         console.error('fetch lotteries', err);
@@ -46,26 +67,49 @@ function LotteryList() {
     );
   };
 
+  const filtered = lotteries.filter((l) =>
+    l.name.toLowerCase().includes(search.toLowerCase())
+  );
+
   return (
     <div className="bodywrapper__inner">
       <div className="d-flex mb-3 justify-content-between align-items-center">
         <h6 className="page-title">Lotteries</h6>
-        <button className="btn btn-primary" onClick={() => navigate('/lottery/create')}>Create</button>
+        <div className="d-flex gap-2">
+          <input
+            type="search"
+            className="form-control"
+            placeholder="Search lottery"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <button className="btn btn-primary" onClick={() => navigate('/lottery/create')}>
+            Create
+          </button>
+        </div>
       </div>
       <table className="table">
         <thead>
           <tr>
+            <th>#</th>
+            <th>Image</th>
             <th>Name</th>
             <th>Price</th>
+            <th>Total Phase</th>
+            <th>Total Draw</th>
             <th>Status</th>
             <th></th>
           </tr>
         </thead>
         <tbody>
-          {lotteries.map((l) => (
+          {filtered.map((l, idx) => (
             <tr key={l.id}>
+              <td>{idx + 1}</td>
+              <td>{l.image && <img src={l.image} alt="thumb" style={{ width: 50 }} />}</td>
               <td>{l.name}</td>
               <td>{l.price}</td>
+              <td>{l.phaseCount}</td>
+              <td>{l.drawCount}</td>
               <td>{l.status ? 'Active' : 'Inactive'}</td>
               <td>
                 <button className="btn btn-sm btn-secondary me-1" onClick={() => handleEdit(l.id)}>Edit</button>


### PR DESCRIPTION
## Summary
- improve lottery list page
- show search input, image, phases/draw counts

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm test --silent` in `raffle-draw-api`

------
https://chatgpt.com/codex/tasks/task_e_688786549940832e8085a0df066badc3