### PR TITLE
Implement admin profile page

### DIFF
--- a/raffle-draw-api/controller/adminController.js
+++ b/raffle-draw-api/controller/adminController.js
@@ -44,6 +44,38 @@ exports.updateAdmin = async (req, res) => {
   }
 };
 
+exports.getProfile = async (req, res) => {
+  try {
+    const admin = await Admin.findById(req.admin.id);
+    if (!admin) {
+      return res.status(404).json({ message: "Admin no encontrado" });
+    }
+    res.json(admin);
+  } catch (err) {
+    res.status(500).json({ message: "Error al obtener perfil", error: err.message });
+  }
+};
+
+exports.updateProfile = async (req, res) => {
+  const { name, email, image } = req.body;
+  try {
+    const current = await Admin.findById(req.admin.id);
+    if (!current) {
+      return res.status(404).json({ message: "Admin no encontrado" });
+    }
+    await Admin.update(req.admin.id, {
+      name: name ?? current.name,
+      email: email ?? current.email,
+      username: current.username,
+      image: image ?? current.image,
+    });
+    const updated = await Admin.findById(req.admin.id);
+    res.json({ message: "Perfil actualizado", user: updated });
+  } catch (err) {
+    res.status(500).json({ message: "Error al actualizar perfil", error: err.message });
+  }
+};
+
 exports.login = async (req, res) => {
   const { email, password } = req.body;
 

--- a/raffle-draw-api/routes/adminRoutes.js
+++ b/raffle-draw-api/routes/adminRoutes.js
@@ -5,14 +5,13 @@ const authenticateToken = require("../middleware/authMiddleware");
 router.post("/login", adminCtrl.login);
 
 // Las siguientes rutas requieren autenticación
+router.get("/profile", authenticateToken, adminCtrl.getProfile);
+router.put("/profile", authenticateToken, adminCtrl.updateProfile);
 router.get("/", authenticateToken, adminCtrl.getAllAdmins);
 router.get("/:id", authenticateToken, adminCtrl.getAdminById);
 router.post("/", authenticateToken, adminCtrl.createAdmin);
 router.put("/:id", authenticateToken, adminCtrl.updateAdmin);
 router.delete("/:id", authenticateToken, adminCtrl.deleteAdmin);
-
-
-router.post("/login", adminCtrl.login);
 
 
 module.exports = router;

--- a/raffle-ui/src/App.js
+++ b/raffle-ui/src/App.js
@@ -8,6 +8,7 @@ import LotteryCreate from './pages/lottery/Create';
 import LotteryEdit from './pages/lottery/Edit';
 import LotteryPhases from './pages/lottery/Phases';
 import WinBonus from './pages/lottery/WinBonus';
+import Profile from './pages/Profile';
 import ProtectedLayout from './layouts/ProtectedLayout';
 
 // Toastify
@@ -105,6 +106,19 @@ function App() {
             isAuthenticated() ? (
               <ProtectedLayout>
                 <WinBonus />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+
+        <Route
+          path="/profile"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <Profile />
               </ProtectedLayout>
             ) : (
               <Navigate to="/Login" />

--- a/raffle-ui/src/components/Navbar.js
+++ b/raffle-ui/src/components/Navbar.js
@@ -154,10 +154,14 @@ const Navbar = () => {
               </span>
             </button>
             <div className="dropdown-menu dropdown-menu--sm p-0 border-0 box--shadow1 dropdown-menu-right">
-              <a href="#" className="dropdown-menu__item d-flex align-items-center px-3 py-2">
+              <button
+                type="button"
+                onClick={() => navigate('/profile')}
+                className="dropdown-menu__item d-flex align-items-center px-3 py-2"
+              >
                 <i className="dropdown-menu__icon las la-user-circle"></i>
                 <span className="dropdown-menu__caption">Profile</span>
-              </a>
+              </button>
 
               <a href="#" className="dropdown-menu__item d-flex align-items-center px-3 py-2">
                 <i className="dropdown-menu__icon las la-key"></i>

--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+
+function Profile() {
+  const [admin, setAdmin] = useState({ name: '', email: '', username: '', image: '' });
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const token = localStorage.getItem('token');
+      try {
+        const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setAdmin(data);
+        }
+      } catch (err) {
+        console.error('Error loading profile', err);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  const handleChange = (e) => {
+    setAdmin({ ...admin, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    try {
+      const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ name: admin.name, email: admin.email, image: admin.image }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setAdmin(data.user);
+        localStorage.setItem('user', JSON.stringify(data.user));
+        toast.success('Profile updated');
+      } else {
+        toast.error('Failed to update profile');
+      }
+    } catch (err) {
+      console.error('Update error', err);
+      toast.error('Error updating profile');
+    }
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <div className="row mb-none-30">
+        <div className="col-xl-3 col-lg-4 mb-30">
+          <div className="card b-radius--5 overflow-hidden">
+            <div className="card-body p-0">
+              <div className="d-flex p-3 bg--primary align-items-center">
+                <div className="avatar avatar--lg">
+                  <img src={admin.image || '/assets/images/avatar.png'} alt="profile" />
+                </div>
+                <div className="ps-3">
+                  <h4 className="text--white">{admin.name}</h4>
+                </div>
+              </div>
+              <ul className="list-group">
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Name <span className="fw-bold">{admin.name}</span>
+                </li>
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Username <span className="fw-bold">{admin.username}</span>
+                </li>
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Email <span className="fw-bold">{admin.email}</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div className="col-xl-9 col-lg-8 mb-30">
+          <div className="card">
+            <div className="card-body">
+              <h5 className="card-title mb-4 border-bottom pb-2">Profile Information</h5>
+              <form onSubmit={handleSubmit}>
+                <div className="row">
+                  <div className="col-md-6">
+                    <div className="form-group">
+                      <label>Name</label>
+                      <input className="form-control" name="name" value={admin.name} onChange={handleChange} />
+                    </div>
+                    <div className="form-group">
+                      <label>Email</label>
+                      <input className="form-control" name="email" type="email" value={admin.email} onChange={handleChange} />
+                    </div>
+                    <div className="form-group">
+                      <label>Image URL</label>
+                      <input className="form-control" name="image" value={admin.image || ''} onChange={handleChange} />
+                    </div>
+                  </div>
+                </div>
+                <button type="submit" className="btn btn--primary btn-block btn-lg">
+                  Save Changes
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Profile;


### PR DESCRIPTION
## Summary
- add `getProfile` and `updateProfile` endpoints on the API
- expose new `/profile` route in admin router
- add React `Profile` page
- link profile from navbar dropdown
- register profile route in React router

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cfe2c828832ea33af3a3e48fb08d