### PR TITLE
Fix profile page data source

### DIFF
--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 
 function Profile() {
-  const [admin, setAdmin] = useState({ name: '', email: '', username: '', image: '' });
+  const storedUser = JSON.parse(localStorage.getItem('user') || '{}');
+  const [admin, setAdmin] = useState({
+    name: storedUser.name || '',
+    email: storedUser.email || '',
+    username: storedUser.username || '',
+    image: storedUser.image || '',
+  });
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -14,6 +20,8 @@ function Profile() {
         if (res.ok) {
           const data = await res.json();
           setAdmin(data);
+        } else {
+          toast.error('Failed to load profile');
         }
       } catch (err) {
         console.error('Error loading profile', err);


### PR DESCRIPTION
## Summary
- load initial profile info from localStorage
- show a toast if fetching profile fails

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6888d207a410832eab9920d1c6186622