### PR TITLE
Fix ResizeObserver error

### DIFF
--- a/raffle-ui/src/index.js
+++ b/raffle-ui/src/index.js
@@ -43,11 +43,7 @@ styleHrefs.forEach((href) => {
 });
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
## Summary
- disable `React.StrictMode` in index.js to avoid ResizeObserver loop errors

## Testing
- `npm --prefix raffle-ui test` *(fails: react-scripts not found)*
- `npm --prefix raffle-draw-api test`

------
https://chatgpt.com/codex/tasks/task_e_6888d35a2c5c832e83e375b9bbf9ba29