### PR TITLE
Fix profile update SQL and toast duration

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -35,6 +35,7 @@ CREATE TABLE `admins` (
   `email_verified_at` timestamp NULL DEFAULT NULL,
   `image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `role` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT 'editor',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -43,11 +44,11 @@ CREATE TABLE `admins` (
 -- Dumping data for table `admins`
 --
 
-INSERT INTO `admins` (`id`, `name`, `email`, `username`, `email_verified_at`, `image`, `password`, `created_at`, `updated_at`) VALUES
-(1, 'Super Admin', 'admin@site.com', 'admin', NULL, '5ff1c3531ed3f1609679699.jpg', '$2y$10$2qcOUKrDIUqyyCklvHp7IO8fGNcJ1gAXtxouTn1isZPHu6H8CfHPq', NULL, '2021-05-07 07:54:06');
+INSERT INTO `admins` (`id`, `name`, `email`, `username`, `email_verified_at`, `image`, `password`, `role`, `created_at`, `updated_at`) VALUES
+(1, 'Super Admin', 'admin@site.com', 'admin', NULL, '5ff1c3531ed3f1609679699.jpg', '$2y$10$2qcOUKrDIUqyyCklvHp7IO8fGNcJ1gAXtxouTn1isZPHu6H8CfHPq', 'superadmin', NULL, '2021-05-07 07:54:06');
 
-INSERT INTO `admins` (`id`, `name`, `email`, `username`, `email_verified_at`, `image`, `password`, `created_at`, `updated_at`) VALUES
-(2, 'Francisco Vergara ', 'fvergara.sand@gmail.comm', 'fvergara', NULL, '5ff1c3531ed3f1609679699.jpg', '$2y$10$2qcOUKrDIUqyyCklvHp7IO8fGNcJ1gAXtxouTn1isZPHu6H8CfHPq', NULL, '2021-05-07 07:54:06');
+INSERT INTO `admins` (`id`, `name`, `email`, `username`, `email_verified_at`, `image`, `password`, `role`, `created_at`, `updated_at`) VALUES
+(2, 'Francisco Vergara ', 'fvergara.sand@gmail.comm', 'fvergara', NULL, '5ff1c3531ed3f1609679699.jpg', '$2y$10$2qcOUKrDIUqyyCklvHp7IO8fGNcJ1gAXtxouTn1isZPHu6H8CfHPq', 'editor', NULL, '2021-05-07 07:54:06');
 
 -- --------------------------------------------------------
 

--- a/raffle-draw-api/db/init.js
+++ b/raffle-draw-api/db/init.js
@@ -46,6 +46,7 @@ async function initialize() {
         email_verified_at TIMESTAMP NULL DEFAULT NULL,
         image VARCHAR(255) DEFAULT NULL,
         password VARCHAR(255) NOT NULL,
+        role VARCHAR(20) DEFAULT 'editor',
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       );

--- a/raffle-ui/src/pages/ForgotPassword.js
+++ b/raffle-ui/src/pages/ForgotPassword.js
@@ -18,14 +18,14 @@ function ForgotPassword() {
       });
       const data = await res.json();
       if (res.ok) {
-        toast.success(data.message?.success?.[0] || 'Code sent');
+        toast.success(data.message?.success?.[0] || 'Code sent', { autoClose: 5000 });
         setEmail(data.data.email);
         setStep('verify');
       } else {
-        toast.error(data.message?.error?.[0] || 'Error sending code');
+        toast.error(data.message?.error?.[0] || 'Error sending code', { autoClose: 5000 });
       }
     } catch (err) {
-      toast.error('Server error');
+      toast.error('Server error', { autoClose: 5000 });
     }
   };
 
@@ -39,12 +39,12 @@ function ForgotPassword() {
       });
       const data = await res.json();
       if (res.ok) {
-        toast.success(data.message?.success?.[0] || 'Code verified');
+        toast.success(data.message?.success?.[0] || 'Code verified', { autoClose: 5000 });
       } else {
-        toast.error(data.message?.error?.[0] || 'Invalid code');
+        toast.error(data.message?.error?.[0] || 'Invalid code', { autoClose: 5000 });
       }
     } catch (err) {
-      toast.error('Server error');
+      toast.error('Server error', { autoClose: 5000 });
     }
   };
 

--- a/raffle-ui/src/pages/Login.js
+++ b/raffle-ui/src/pages/Login.js
@@ -20,7 +20,7 @@ function Login() {
       if (res.ok) {
         localStorage.setItem('token', data.token);
         localStorage.setItem('user', JSON.stringify(data.user)); // save the user
-        toast.success('Login exitoso');
+        toast.success('Login exitoso', { autoClose: 5000 });
         navigate('/Dashboard');
        
       } else {

--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -21,7 +21,7 @@ function Profile() {
           const data = await res.json();
           setAdmin(data);
         } else {
-          toast.error('Failed to load profile');
+          toast.error('Failed to load profile', { autoClose: 5000 });
         }
       } catch (err) {
         console.error('Error loading profile', err);
@@ -47,13 +47,13 @@ function Profile() {
         const data = await res.json();
         setAdmin(data.user);
         localStorage.setItem('user', JSON.stringify(data.user));
-        toast.success('Profile updated');
+        toast.success('Profile updated', { autoClose: 5000 });
       } else {
-        toast.error('Failed to update profile');
+        toast.error('Failed to update profile', { autoClose: 5000 });
       }
     } catch (err) {
       console.error('Update error', err);
-      toast.error('Error updating profile');
+      toast.error('Error updating profile', { autoClose: 5000 });
     }
   };
 


### PR DESCRIPTION
## Summary
- fix DB initialization to include `role` column
- keep `role` column in SQL dump
- show toast notifications for 5 seconds on login, password reset and profile update

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm --prefix raffle-draw-api test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6888d587d2b0832e8381747f54849a41