### PR TITLE
Fix profile requests

### DIFF
--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
+import { apiFetch } from '../utils/api';
 
 function Profile() {
   const storedUser = JSON.parse(localStorage.getItem('user') || '{}');
@@ -13,11 +14,10 @@ function Profile() {
 
   useEffect(() => {
     const fetchProfile = async () => {
-      const token = localStorage.getItem('token');
       try {
-        const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const res = await apiFetch(
+          `${process.env.REACT_APP_API_URL}/api/v1/admin/profile`
+        );
         if (res.ok) {
           const data = await res.json();
           setAdmin(data);
@@ -48,11 +48,10 @@ function Profile() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const token = localStorage.getItem('token');
     try {
-      const res = await fetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`, {
+      const res = await apiFetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: admin.name, email: admin.email, image: admin.image }),
       });
       if (res.ok) {

--- a/raffle-ui/src/utils/api.js
+++ b/raffle-ui/src/utils/api.js
@@ -1,0 +1,8 @@
+export async function apiFetch(url, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = options.headers ? { ...options.headers } : {};
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return fetch(url, { ...options, headers });
+}


### PR DESCRIPTION
## Summary
- centralize API calls with `apiFetch`
- use the helper in Profile to ensure Authorization header is set

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a285699a4832e93a1c829ce77197c