### PR TITLE
Fix reCAPTCHA render error

### DIFF
--- a/raffle-ui/src/components/Recaptcha.js
+++ b/raffle-ui/src/components/Recaptcha.js
@@ -10,10 +10,15 @@ const Recaptcha = ({ siteKey, onVerify }) => {
 
     const renderCaptcha = () => {
       if (window.grecaptcha && siteKey) {
-        window.grecaptcha.render('recaptcha-container', {
-          sitekey: siteKey,
-          callback: onVerify,
-        });
+        // ensure the API is fully loaded before attempting to render
+        if (typeof window.grecaptcha.render === 'function') {
+          window.grecaptcha.ready(() => {
+            window.grecaptcha.render('recaptcha-container', {
+              sitekey: siteKey,
+              callback: onVerify,
+            });
+          });
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- handle async loading of Google reCAPTCHA script

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4b3a1fa4832eb463558be01d11fe