### PR TITLE
Fix profile image upload

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -33,7 +33,7 @@ CREATE TABLE `admins` (
   `email` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,
   `username` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,
   `email_verified_at` timestamp NULL DEFAULT NULL,
-  `image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `image` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `role` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT 'editor',
   `created_at` timestamp NULL DEFAULT NULL,

--- a/raffle-draw-api/db/init.js
+++ b/raffle-draw-api/db/init.js
@@ -53,7 +53,7 @@ async function initialize() {
         email VARCHAR(40) NOT NULL UNIQUE,
         username VARCHAR(40) NOT NULL UNIQUE,
         email_verified_at TIMESTAMP NULL DEFAULT NULL,
-        image VARCHAR(255) DEFAULT NULL,
+        image LONGTEXT DEFAULT NULL,
         password VARCHAR(255) NOT NULL,
         role VARCHAR(20) DEFAULT 'editor',
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- increase `admins.image` column size to store uploaded images

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4dd59c1c832eb51028ea6bec715a