### PR TITLE
Fix navbar profile image update

### DIFF
--- a/raffle-draw-api/controller/adminController.js
+++ b/raffle-draw-api/controller/adminController.js
@@ -107,6 +107,7 @@ exports.login = async (req, res) => {
         name: admin.name,
         email: admin.email,
         username: admin.username,
+        image: admin.image,
       },
     });
   } catch (error) {

--- a/raffle-ui/src/components/Navbar.js
+++ b/raffle-ui/src/components/Navbar.js
@@ -4,7 +4,9 @@ import { useNavigate } from 'react-router-dom';
 const Navbar = () => {
   const navigate = useNavigate();
   const [notifications, setNotifications] = useState([]);
-  const user = JSON.parse(localStorage.getItem('user')) || { name: 'admin' };
+  const [user, setUser] = useState(
+    () => JSON.parse(localStorage.getItem('user')) || { name: 'admin' }
+  );
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -27,7 +29,18 @@ const Navbar = () => {
       }
     };
 
+    const updateUser = () => {
+      setUser(JSON.parse(localStorage.getItem('user')) || { name: 'admin' });
+    };
+
     fetchNotifications();
+    window.addEventListener('profileUpdated', updateUser);
+    window.addEventListener('storage', updateUser);
+
+    return () => {
+      window.removeEventListener('profileUpdated', updateUser);
+      window.removeEventListener('storage', updateUser);
+    };
   }, []);
 
   const notificationCount =
@@ -141,7 +154,13 @@ const Navbar = () => {
               <span className="navbar-user">
                 <span className="navbar-user__thumb">
                   <img
-                    src="https://script.viserlab.com/lottolab/assets/admin/images/profile/66619f5b5c6091717673819.png"
+                    src={
+                      user.image
+                        ? user.image.startsWith('data')
+                          ? user.image
+                          : `/assets/admin/images/profile/${user.image}`
+                        : '/assets/admin/images/profile/profile.png'
+                    }
                     alt="profile"
                   />
                 </span>

--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -58,6 +58,7 @@ function Profile() {
         const data = await res.json();
         setAdmin(data.user);
         localStorage.setItem('user', JSON.stringify(data.user));
+        window.dispatchEvent(new Event('profileUpdated'));
         toast.success('Profile updated', { autoClose: 5000 });
       } else {
         toast.error('Failed to update profile', { autoClose: 5000 });
@@ -83,7 +84,7 @@ function Profile() {
                         ? admin.image.startsWith('data')
                           ? admin.image
                           : `/assets/admin/images/profile/${admin.image}`
-                        : '/assets/images/default.png')
+                        : '/assets/admin/images/profile/profile.png')
                     }
                     alt="profile"
                   />
@@ -134,7 +135,7 @@ function Profile() {
                                   ? admin.image.startsWith('data')
                                     ? admin.image
                                     : `/assets/admin/images/profile/${admin.image}`
-                                  : '/assets/images/default.png')
+                                  : '/assets/admin/images/profile/profile.png')
                               })`,
                             }}
                           ></div>


### PR DESCRIPTION
## Summary
- update login response to include user image
- refresh navbar user state when profile changes
- use default profile image when none is set
- dispatch an event when profile updates

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b55585878832eb02336ac4813a1b3