### PR TITLE
Fix toast auto close timing

### DIFF
--- a/raffle-ui/src/App.js
+++ b/raffle-ui/src/App.js
@@ -24,10 +24,10 @@ function App() {
     <BrowserRouter>
       <ToastContainer
         position="top-right"
-        autoClose={5000}
+        autoClose={3000}
         hideProgressBar={false}
         newestOnTop={false}
-        closeOnClick
+        closeOnClick={false}
         rtl={false}
         pauseOnFocusLoss
         draggable

--- a/raffle-ui/src/pages/ForgotPassword.js
+++ b/raffle-ui/src/pages/ForgotPassword.js
@@ -18,14 +18,14 @@ function ForgotPassword() {
       });
       const data = await res.json();
       if (res.ok) {
-        toast.success(data.message?.success?.[0] || 'Code sent', { autoClose: 5000 });
+        toast.success(data.message?.success?.[0] || 'Code sent');
         setEmail(data.data.email);
         setStep('verify');
       } else {
-        toast.error(data.message?.error?.[0] || 'Error sending code', { autoClose: 5000 });
+        toast.error(data.message?.error?.[0] || 'Error sending code');
       }
     } catch (err) {
-      toast.error('Server error', { autoClose: 5000 });
+      toast.error('Server error');
     }
   };
 
@@ -39,12 +39,12 @@ function ForgotPassword() {
       });
       const data = await res.json();
       if (res.ok) {
-        toast.success(data.message?.success?.[0] || 'Code verified', { autoClose: 5000 });
+        toast.success(data.message?.success?.[0] || 'Code verified');
       } else {
-        toast.error(data.message?.error?.[0] || 'Invalid code', { autoClose: 5000 });
+        toast.error(data.message?.error?.[0] || 'Invalid code');
       }
     } catch (err) {
-      toast.error('Server error', { autoClose: 5000 });
+      toast.error('Server error');
     }
   };
 

--- a/raffle-ui/src/pages/Login.js
+++ b/raffle-ui/src/pages/Login.js
@@ -28,7 +28,7 @@ function Login() {
       if (res.ok) {
         localStorage.setItem('token', data.token);
         localStorage.setItem('user', JSON.stringify(data.user)); // save the user
-        toast.success('Login exitoso', { autoClose: 5000 });
+        toast.success('Login exitoso');
         navigate('/Dashboard');
        
       } else {

--- a/raffle-ui/src/pages/Profile.js
+++ b/raffle-ui/src/pages/Profile.js
@@ -22,7 +22,7 @@ function Profile() {
           const data = await res.json();
           setAdmin(data);
         } else {
-          toast.error('Failed to load profile', { autoClose: 5000 });
+          toast.error('Failed to load profile');
         }
       } catch (err) {
         console.error('Error loading profile', err);
@@ -59,13 +59,13 @@ function Profile() {
         setAdmin(data.user);
         localStorage.setItem('user', JSON.stringify(data.user));
         window.dispatchEvent(new Event('profileUpdated'));
-        toast.success('Profile updated', { autoClose: 5000 });
+        toast.success('Profile updated');
       } else {
-        toast.error('Failed to update profile', { autoClose: 5000 });
+        toast.error('Failed to update profile');
       }
     } catch (err) {
       console.error('Update error', err);
-      toast.error('Error updating profile', { autoClose: 5000 });
+      toast.error('Error updating profile');
     }
   };
 


### PR DESCRIPTION
## Summary
- set ToastContainer closeOnClick disabled and reduce default timeout
- adjust toast calls to use the shared default

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b5a0013e8832e8f60ec35d662d83c