### PR TITLE
style: match login and reset password buttons with PHP version

### DIFF
--- a/raffle-ui/src/pages/ForgotPassword.js
+++ b/raffle-ui/src/pages/ForgotPassword.js
@@ -97,7 +97,17 @@ function ForgotPassword() {
                           onVerify={setCaptchaToken}
                         />
                       </div>
-                      <button type="submit" className="btn cmn-btn w-100">
+                      <button
+                        type="submit"
+                        className="btn cmn-btn w-100"
+                        style={{
+                          backgroundColor: '#3d2bfb',
+                          color: '#fff',
+                          height: '50px',
+                          marginTop: '15px',
+                          borderRadius: '3.2px',
+                        }}
+                      >
                         Submit
                       </button>
                       <div className="text-center mt-3">
@@ -122,7 +132,17 @@ function ForgotPassword() {
                           required
                         />
                       </div>
-                      <button type="submit" className="btn cmn-btn w-100">
+                      <button
+                        type="submit"
+                        className="btn cmn-btn w-100"
+                        style={{
+                          backgroundColor: '#3d2bfb',
+                          color: '#fff',
+                          height: '50px',
+                          marginTop: '15px',
+                          borderRadius: '3.2px',
+                        }}
+                      >
                         Verify Code
                       </button>
                     </form>

--- a/raffle-ui/src/pages/Login.js
+++ b/raffle-ui/src/pages/Login.js
@@ -126,7 +126,17 @@ function Login() {
                         onVerify={setCaptchaToken}
                       />
                     </div>
-                    <button type="submit" className="btn cmn-btn w-100">
+                    <button
+                      type="submit"
+                      className="btn cmn-btn w-100"
+                      style={{
+                        backgroundColor: '#3d2bfb',
+                        color: '#fff',
+                        height: '50px',
+                        marginTop: '15px',
+                        borderRadius: '3.2px',
+                      }}
+                    >
                       LOGIN
                     </button>
                   </form>


### PR DESCRIPTION
## Summary
- style login button to match PHP application's appearance
- style reset password buttons to match PHP application's appearance

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68904d9eaac8832e91a303cedd419b7e