### PR TITLE
fix: suppress ResizeObserver loop errors

### DIFF
--- a/raffle-ui/src/index.js
+++ b/raffle-ui/src/index.js
@@ -42,6 +42,15 @@ styleHrefs.forEach((href) => {
   document.head.appendChild(link);
 });
 
+// Work around ResizeObserver loop errors in some browsers
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', (e) => {
+    if (e.message === 'ResizeObserver loop completed with undelivered notifications.') {
+      e.stopImmediatePropagation();
+    }
+  });
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);
 


### PR DESCRIPTION
## Summary
- suppress ResizeObserver loop errors globally

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_6891edd48f7c832e8535311830d8711d