### PR TITLE
Add admin password change page and API support

### DIFF
--- a/raffle-draw-api/controller/adminController.js
+++ b/raffle-draw-api/controller/adminController.js
@@ -117,6 +117,42 @@ exports.login = async (req, res) => {
 };
 
 
+exports.changePassword = async (req, res) => {
+  const { current_password, password, password_confirmation } = req.body;
+
+  if (!current_password || !password || !password_confirmation) {
+    return res
+      .status(400)
+      .json({ message: "Faltan campos obligatorios" });
+  }
+
+  if (password !== password_confirmation) {
+    return res.status(400).json({ message: "Las contraseñas no coinciden" });
+  }
+
+  try {
+    const admin = await Admin.findById(req.admin.id);
+    if (!admin) {
+      return res.status(404).json({ message: "Admin no encontrado" });
+    }
+
+    const match = await bcrypt.compare(current_password, admin.password);
+    if (!match) {
+      return res
+        .status(400)
+        .json({ message: "La contraseña actual es incorrecta" });
+    }
+
+    await Admin.updatePassword(admin.id, password);
+    return res.json({ message: "Contraseña actualizada" });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ message: "Error al cambiar contraseña", error: err.message });
+  }
+};
+
+
 exports.deleteAdmin = async (req, res) => {
   try {
     await Admin.delete(req.params.id);

--- a/raffle-draw-api/models/adminModel.js
+++ b/raffle-draw-api/models/adminModel.js
@@ -45,6 +45,15 @@ const Admin = {
     return result;
   },
 
+  updatePassword: async (id, password) => {
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const [result] = await db.query(
+      "UPDATE admins SET password = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+      [hashedPassword, id]
+    );
+    return result;
+  },
+
   delete: async (id) => {
     const [result] = await db.query("DELETE FROM admins WHERE id = ?", [id]);
     return result;

--- a/raffle-draw-api/routes/adminRoutes.js
+++ b/raffle-draw-api/routes/adminRoutes.js
@@ -7,6 +7,7 @@ router.post("/login", adminCtrl.login);
 // Las siguientes rutas requieren autenticación
 router.get("/profile", authenticateToken, adminCtrl.getProfile);
 router.put("/profile", authenticateToken, adminCtrl.updateProfile);
+router.post("/change-password", authenticateToken, adminCtrl.changePassword);
 router.get("/", authenticateToken, adminCtrl.getAllAdmins);
 router.get("/:id", authenticateToken, adminCtrl.getAdminById);
 router.post("/", authenticateToken, adminCtrl.createAdmin);

--- a/raffle-ui/src/App.js
+++ b/raffle-ui/src/App.js
@@ -9,6 +9,7 @@ import LotteryEdit from './pages/lottery/Edit';
 import LotteryPhases from './pages/lottery/Phases';
 import WinBonus from './pages/lottery/WinBonus';
 import Profile from './pages/Profile';
+import Password from './pages/Password';
 import ProtectedLayout from './layouts/ProtectedLayout';
 
 // Toastify
@@ -119,6 +120,18 @@ function App() {
             isAuthenticated() ? (
               <ProtectedLayout>
                 <Profile />
+              </ProtectedLayout>
+            ) : (
+              <Navigate to="/Login" />
+            )
+          }
+        />
+        <Route
+          path="/password"
+          element={
+            isAuthenticated() ? (
+              <ProtectedLayout>
+                <Password />
               </ProtectedLayout>
             ) : (
               <Navigate to="/Login" />

--- a/raffle-ui/src/components/Navbar.js
+++ b/raffle-ui/src/components/Navbar.js
@@ -182,10 +182,14 @@ const Navbar = () => {
                 <span className="dropdown-menu__caption">Profile</span>
               </button>
 
-              <a href="#" className="dropdown-menu__item d-flex align-items-center px-3 py-2">
+              <button
+                type="button"
+                onClick={() => navigate('/password')}
+                className="dropdown-menu__item d-flex align-items-center px-3 py-2"
+              >
                 <i className="dropdown-menu__icon las la-key"></i>
                 <span className="dropdown-menu__caption">Password</span>
-              </a>
+              </button>
 
               <button type="button" onClick={handleLogout} className="dropdown-menu__item d-flex align-items-center px-3 py-2">
                 <i className="dropdown-menu__icon las la-sign-out-alt"></i>

--- a/raffle-ui/src/pages/Password.js
+++ b/raffle-ui/src/pages/Password.js
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { apiFetch } from '../utils/api';
+
+function Password() {
+  const [admin, setAdmin] = useState({ name: '', email: '', username: '', image: '' });
+  const [form, setForm] = useState({
+    current_password: '',
+    password: '',
+    password_confirmation: '',
+  });
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await apiFetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/profile`);
+        if (res.ok) {
+          const data = await res.json();
+          setAdmin(data);
+        }
+      } catch (err) {
+        console.error('Error fetching profile', err);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.current_password || !form.password || !form.password_confirmation) {
+      toast.error('All fields are required');
+      return;
+    }
+    if (form.password !== form.password_confirmation) {
+      toast.error('Passwords do not match');
+      return;
+    }
+    try {
+      const res = await apiFetch(`${process.env.REACT_APP_API_URL}/api/v1/admin/change-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || 'Password updated');
+        setForm({ current_password: '', password: '', password_confirmation: '' });
+      } else {
+        toast.error(data.message || 'Failed to update password');
+      }
+    } catch (err) {
+      console.error('Error updating password', err);
+      toast.error('Error updating password');
+    }
+  };
+
+  return (
+    <div className="bodywrapper__inner">
+      <div className="row mb-none-30">
+        <div className="col-xl-3 col-lg-4 mb-30">
+          <div className="card b-radius--5 overflow-hidden">
+            <div className="card-body p-0">
+              <div className="d-flex p-3 bg--primary align-items-center">
+                <div className="avatar avatar--lg">
+                  <img
+                    src={
+                      admin.image
+                        ? admin.image.startsWith('data')
+                          ? admin.image
+                          : `/assets/admin/images/profile/${admin.image}`
+                        : '/assets/admin/images/profile/profile.png'
+                    }
+                    alt="profile"
+                  />
+                </div>
+                <div className="ps-3">
+                  <h4 className="text--white">{admin.name}</h4>
+                </div>
+              </div>
+              <ul className="list-group">
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Name <span className="fw-bold">{admin.name}</span>
+                </li>
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Username <span className="fw-bold">{admin.username}</span>
+                </li>
+                <li className="list-group-item d-flex justify-content-between align-items-center">
+                  Email <span className="fw-bold">{admin.email}</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div className="col-xl-9 col-lg-8 mb-30">
+          <div className="card">
+            <div className="card-body">
+              <h5 className="card-title mb-4 border-bottom pb-2">Change Password</h5>
+              <form onSubmit={handleSubmit}>
+                <div className="form-group row">
+                  <label className="col-lg-3 col-form-label form-control-label">Current Password</label>
+                  <div className="col-lg-9">
+                    <input
+                      className="form-control"
+                      type="password"
+                      name="current_password"
+                      value={form.current_password}
+                      onChange={handleChange}
+                    />
+                  </div>
+                </div>
+                <div className="form-group row">
+                  <label className="col-lg-3 col-form-label form-control-label">New Password</label>
+                  <div className="col-lg-9">
+                    <input
+                      className="form-control"
+                      type="password"
+                      name="password"
+                      value={form.password}
+                      onChange={handleChange}
+                    />
+                  </div>
+                </div>
+                <div className="form-group row">
+                  <label className="col-lg-3 col-form-label form-control-label">Confirm Password</label>
+                  <div className="col-lg-9">
+                    <input
+                      className="form-control"
+                      type="password"
+                      name="password_confirmation"
+                      value={form.password_confirmation}
+                      onChange={handleChange}
+                    />
+                  </div>
+                </div>
+                <div className="form-group row">
+                  <label className="col-lg-3 col-form-label form-control-label"></label>
+                  <div className="col-lg-9">
+                    <button type="submit" className="btn btn--primary btn-block btn-lg">
+                      Save Changes
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Password;


### PR DESCRIPTION
## Summary
- add API endpoint for admins to update passwords
- create password change page and navigation in React UI
- wire navbar item to password settings page

## Testing
- `npm test` (raffle-draw-api)
- `CI=true npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')


------
https://chatgpt.com/codex/tasks/task_e_6891fad6aadc832e82d9196c20fba659