### PR TITLE
Fix password change form layout

### DIFF
--- a/php lottery/core/resources/views/admin/password.blade.php
+++ b/php lottery/core/resources/views/admin/password.blade.php
@@ -35,39 +35,27 @@
         <div class="col-lg-9 col-md-9 mb-30">
             <div class="card">
                 <div class="card-body">
-                    <h5 class="card-title mb-50 border-bottom pb-2">@lang('Change Password')</h5>
+                    <h5 class="card-title mb-4 border-bottom pb-2">@lang('Change Password')</h5>
 
                     <form action="{{ route('admin.password.update') }}" method="POST" enctype="multipart/form-data">
                         @csrf
 
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label form-control-label">@lang('Password')</label>
-                            <div class="col-lg-9">
-                                <input class="form-control" type="password" placeholder="@lang('Password')" name="old_password">
-                            </div>
+                        <div class="form-group">
+                            <label for="old_password" class="required">@lang('Password')</label>
+                            <input class="form-control" type="password" placeholder="@lang('Password')" name="old_password" id="old_password" required>
                         </div>
 
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label form-control-label">@lang('New Password')</label>
-                            <div class="col-lg-9">
-                                <input class="form-control" type="password" placeholder="@lang('New Password')" name="password">
-                            </div>
+                        <div class="form-group">
+                            <label for="password" class="required">@lang('New Password')</label>
+                            <input class="form-control" type="password" placeholder="@lang('New Password')" name="password" id="password" required>
                         </div>
 
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label form-control-label">@lang('Confirm Password')</label>
-                            <div class="col-lg-9">
-                                <input class="form-control" type="password" placeholder="@lang('Confirm Password')" name="password_confirmation">
-                            </div>
+                        <div class="form-group">
+                            <label for="password_confirmation" class="required">@lang('Confirm Password')</label>
+                            <input class="form-control" type="password" placeholder="@lang('Confirm Password')" name="password_confirmation" id="password_confirmation" required>
                         </div>
 
-
-                        <div class="form-group row">
-                            <label class="col-lg-3 col-form-label form-control-label"></label>
-                            <div class="col-lg-9">
-                            <button type="submit" class="btn btn--primary btn-block btn-lg">@lang('Save Changes')</button>
-                            </div>
-                        </div>
+                        <button type="submit" class="btn btn--primary w-100 btn-lg h-45">@lang('Submit')</button>
                     </form>
                 </div>
             </div>

--- a/raffle-ui/src/pages/Password.js
+++ b/raffle-ui/src/pages/Password.js
@@ -100,50 +100,45 @@ function Password() {
             <div className="card-body">
               <h5 className="card-title mb-4 border-bottom pb-2">Change Password</h5>
               <form onSubmit={handleSubmit}>
-                <div className="form-group row">
-                  <label className="col-lg-3 col-form-label form-control-label">Current Password</label>
-                  <div className="col-lg-9">
-                    <input
-                      className="form-control"
-                      type="password"
-                      name="current_password"
-                      value={form.current_password}
-                      onChange={handleChange}
-                    />
-                  </div>
+                <div className="form-group">
+                  <label htmlFor="old_password" className="required">Password</label>
+                  <input
+                    className="form-control"
+                    type="password"
+                    name="current_password"
+                    id="old_password"
+                    required
+                    value={form.current_password}
+                    onChange={handleChange}
+                  />
                 </div>
-                <div className="form-group row">
-                  <label className="col-lg-3 col-form-label form-control-label">New Password</label>
-                  <div className="col-lg-9">
-                    <input
-                      className="form-control"
-                      type="password"
-                      name="password"
-                      value={form.password}
-                      onChange={handleChange}
-                    />
-                  </div>
+                <div className="form-group">
+                  <label htmlFor="password" className="required">New Password</label>
+                  <input
+                    className="form-control"
+                    type="password"
+                    name="password"
+                    id="password"
+                    required
+                    value={form.password}
+                    onChange={handleChange}
+                  />
                 </div>
-                <div className="form-group row">
-                  <label className="col-lg-3 col-form-label form-control-label">Confirm Password</label>
-                  <div className="col-lg-9">
-                    <input
-                      className="form-control"
-                      type="password"
-                      name="password_confirmation"
-                      value={form.password_confirmation}
-                      onChange={handleChange}
-                    />
-                  </div>
+                <div className="form-group">
+                  <label htmlFor="password_confirmation" className="required">Confirm Password</label>
+                  <input
+                    className="form-control"
+                    type="password"
+                    name="password_confirmation"
+                    id="password_confirmation"
+                    required
+                    value={form.password_confirmation}
+                    onChange={handleChange}
+                  />
                 </div>
-                <div className="form-group row">
-                  <label className="col-lg-3 col-form-label form-control-label"></label>
-                  <div className="col-lg-9">
-                    <button type="submit" className="btn btn--primary btn-block btn-lg">
-                      Save Changes
-                    </button>
-                  </div>
-                </div>
+                <button type="submit" className="btn btn--primary w-100 btn-lg h-45">
+                  Submit
+                </button>
               </form>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- switch admin password page to single-column form with required labels
- align React password component with new design and button styling

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')
- `php artisan test` (fails: multiple deprecation warnings)


------
https://chatgpt.com/codex/tasks/task_e_68921370a710832e8a77b418444f23df