### PR TITLE
fix admin password change

### DIFF
--- a/raffle-draw-api/controller/adminController.js
+++ b/raffle-draw-api/controller/adminController.js
@@ -131,7 +131,7 @@ exports.changePassword = async (req, res) => {
   }
 
   try {
-    const admin = await Admin.findById(req.admin.id);
+    const admin = await Admin.findByIdWithPassword(req.admin.id);
     if (!admin) {
       return res.status(404).json({ message: "Admin no encontrado" });
     }

--- a/raffle-draw-api/models/adminModel.js
+++ b/raffle-draw-api/models/adminModel.js
@@ -18,6 +18,14 @@ const Admin = {
     return rows[0];
   },
 
+  findByIdWithPassword: async (id) => {
+    const [rows] = await db.query(
+      "SELECT id, name, email, username, image, role, password, created_at, updated_at FROM admins WHERE id = ?",
+      [id]
+    );
+    return rows[0];
+  },
+
   findByEmail: async (email) => {
     const [rows] = await db.query("SELECT * FROM admins WHERE email = ?", [email]);
     return rows;


### PR DESCRIPTION
## Summary
- add model helper to retrieve admin with password hash
- use password hash in change-password endpoint for validation

## Testing
- `cd raffle-draw-api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68936d59866c832eb0af7df734d37da3