### PR TITLE
Add registration and admin guard middleware

### DIFF
--- a/raffle-draw-api/middleware/allowRegistration.js
+++ b/raffle-draw-api/middleware/allowRegistration.js
@@ -1,0 +1,19 @@
+const GeneralSetting = require('../models/generalSettingModel');
+
+/**
+ * Middleware to block requests when user registration is disabled
+ * in the system settings.
+ */
+async function allowRegistration(req, res, next) {
+  try {
+    const settings = await GeneralSetting.getSettings();
+    if (settings && settings.registration === 0) {
+      return res.status(403).json({ message: 'Registration is currently disabled.' });
+    }
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = allowRegistration;

--- a/raffle-draw-api/middleware/redirectIfNotAdmin.js
+++ b/raffle-draw-api/middleware/redirectIfNotAdmin.js
@@ -1,0 +1,23 @@
+const Admin = require('../models/adminModel');
+
+/**
+ * Ensures the authenticated user has an admin role.
+ * Expects previous middleware to populate `req.admin` with the user info.
+ */
+async function redirectIfNotAdmin(req, res, next) {
+  if (!req.admin) {
+    return res.status(401).json({ message: 'Authentication required' });
+  }
+
+  try {
+    const admin = await Admin.findById(req.admin.id);
+    if (!admin || admin.role !== 'superadmin') {
+      return res.status(403).json({ message: 'Admin access required' });
+    }
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = redirectIfNotAdmin;

--- a/raffle-draw-api/models/generalSettingModel.js
+++ b/raffle-draw-api/models/generalSettingModel.js
@@ -1,0 +1,14 @@
+const db = require('../db/mysql');
+
+const GeneralSetting = {
+  /**
+   * Fetch the single row from general_settings table.
+   * Assumes only one row exists.
+   */
+  async getSettings() {
+    const [rows] = await db.query('SELECT * FROM general_settings LIMIT 1');
+    return rows[0];
+  },
+};
+
+module.exports = GeneralSetting;


### PR DESCRIPTION
## Summary
- add GeneralSetting model to query site configuration
- add middleware to block registration when disabled
- add middleware to restrict access to superadmin users

## Testing
- `cd raffle-draw-api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f3dea4f4832ea108644a4a5cdc94